### PR TITLE
feat: only hide the popout button that triggered the popout window

### DIFF
--- a/ipypopout/popout_button.vue
+++ b/ipypopout/popout_button.vue
@@ -53,7 +53,8 @@ module.exports = {
       window.open(this.getUrl(), '_blank');
     },
     isInPopupMode() {
-      return window.location.pathname.includes(this.popoutPageUrl);
+      const params = new URLSearchParams(window.location.search);
+      return params.get('modelid') == this.target_model_id;
     },
     jupyter_open_window() {
       this.openWindow();


### PR DESCRIPTION
Before, each popout button would hide all other popout buttons in the
new tab/window. However, a popout window should be able to contain
other popout buttons.