### PR TITLE
feat: solara support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,9 +90,6 @@ jobs:
         run: playwright install chromium
 
       - name: Run ui-tests
-        env:
-          # do not run solara (yet)
-          SOLARA_TEST_RUNNERS: "jupyter_lab,jupyter_notebook,voila"
         run: pytest tests/ui/ --video=retain-on-failure --solara-update-snapshots-ci -s
 
       - name: Upload Test artifacts
@@ -128,4 +125,3 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload --skip-existing dist/*
-

--- a/ipypopout/popout_button.py
+++ b/ipypopout/popout_button.py
@@ -4,9 +4,20 @@ import IPython
 import traitlets
 import ipywidgets
 import ipyvuetify as v
+import sys
 
 
 def get_kernel_id():
+    if "solara" in sys.modules:
+        import solara
+        if solara._using_solara_server():
+            try:
+                import solara.server.kernel_context
+
+                context = solara.server.kernel_context.get_current_context()
+                return context.id
+            except RuntimeError:
+                pass
     ipython = IPython.get_ipython()
     if not ipython or not hasattr(ipython, 'kernel'):
         return ''

--- a/ipypopout/popout_button.vue
+++ b/ipypopout/popout_button.vue
@@ -65,6 +65,9 @@ module.exports = {
   },
   computed: {
     popoutPageUrl() {
+       if (window.solara && (solara.rootPath !== undefined)) {
+        return solara.rootPath;
+      }
       return 'voila/templates/ipypopout/static/popout.html'
     }
   }

--- a/tests/ui/popout_test.py
+++ b/tests/ui/popout_test.py
@@ -28,4 +28,11 @@ def test_popout(
     new_page.locator("text=Test ipypopout").wait_for()
     # the button should not be on the page
     new_page.locator("_vue=v-btn").wait_for(state="detached")
+    # if we do not go to a blank page, on solara, the server will not get the close beacon
+    # and the kernel will not shut down
+    new_page.goto("about:blank")
+    # wait for the kernel to shut down, if we close the page to early
+    # it seem again the server will not get the close beacon
+    # and solara's test framework fails
+    new_page.wait_for_timeout(1000)
     new_page.close()


### PR DESCRIPTION
feat: only hide the popout button that triggered the popout window

Before, each popout button would hide all other popout buttons in the
new tab/window. However, a popout window should be able to contain
other popout buttons.

feat: support solara in the frontend

When using the solara server, the popout url is be the root url
of the solara server.

feat: support solara server by getting the kernel id from solara.