### PR TITLE
fix: incorrect popout-url with solara with non-empty root-path

### DIFF
--- a/ipypopout/popout_button.vue
+++ b/ipypopout/popout_button.vue
@@ -33,7 +33,7 @@ module.exports = {
     getBaseUrl() {
       const labConfigData = document.getElementById('jupyter-config-data');
       if (labConfigData) {
-        /* lab and Voila */
+        /* lab, Voila, and Solara */
         return JSON.parse(labConfigData.textContent).baseUrl;
       }
       return document.body.dataset.baseUrl
@@ -67,7 +67,7 @@ module.exports = {
   computed: {
     popoutPageUrl() {
        if (window.solara && (solara.rootPath !== undefined)) {
-        return solara.rootPath;
+        return ""
       }
       return 'voila/templates/ipypopout/static/popout.html'
     }


### PR DESCRIPTION
Should fix https://github.com/widgetti/ipypopout/issues/12.

I tested that everything works with:
- jupyter notebook
- jupyter lab
- solara
- solara under fastapi